### PR TITLE
fixes waffleio/hackshop#14

### DIFF
--- a/content/cards-organizer.json
+++ b/content/cards-organizer.json
@@ -47,7 +47,7 @@
     {
         "title": "Setup your Social Media",
         "file": "11SetupSocialMedia.md",
-        "labels": ["2 week before"]
+        "labels": ["1 month before"]
     },
     {
         "title": "Check AV",


### PR DESCRIPTION
From my experience, social media set up is best started 1 month out if possible, so I went ahead and updated the label to "1 month before" (the current label is actually misspelled anyways -- "2 week before" rather than "2 weeks before") "
